### PR TITLE
feat(module): Update image source handling

### DIFF
--- a/components/module/Image.vue
+++ b/components/module/Image.vue
@@ -14,6 +14,7 @@ interface Props {
 const props = defineProps<Props>()
 const flow = inject('flow') as FlowOutput
 const text = computed(() => extractTextFromHTML(props.module.content))
+const cover = props.module.s3Key ? `https://space.r2.102415.xyz/${props.module.s3Key}` : props.module.image
 </script>
 
 <template>
@@ -34,7 +35,7 @@ const text = computed(() => extractTextFromHTML(props.module.content))
 				<NuxtImg
 					class="w-full"
 					format="webp"
-					:src="props.module!.image"
+					:src="cover || undefined"
 					:alt="module.title"
 					referrerpolicy="no-referrer"
 					loading="lazy"

--- a/components/module/Project.vue
+++ b/components/module/Project.vue
@@ -11,6 +11,7 @@ interface Props {
 }
 
 const props = defineProps<Props>()
+const cover = props.module.s3Key ? `https://space.r2.102415.xyz/${props.module.s3Key}` : props.module.image
 </script>
 
 <template>
@@ -20,7 +21,7 @@ const props = defineProps<Props>()
 				<NuxtImg
 					width="48px"
 					height="48px"
-					:src="props.module.image ?? undefined"
+					:src="cover || undefined"
 					loading="lazy"
 					:alt="props.module.title"
 				/>


### PR DESCRIPTION
Added logic to check for props.module.s3Key and set the image source accordingly in Image.vue and Project.vue components. Cover image is now used if available; otherwise, the default image src is used.